### PR TITLE
Remove MicroPython from software.yml

### DIFF
--- a/software.yml
+++ b/software.yml
@@ -1,3 +1,2 @@
 - Python 3 Picamera
-- MicroPython
 - mu


### PR DESCRIPTION
AFAIK MicroPython runs on the microbit, and so shouldn't be included in software.yml which details software that runs on the Pi?

Feel free to close this PR if I've got this wrong ;-)
